### PR TITLE
Python sub path fix and SSL verification settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ remove_tmpl_dir = $(1:$(TEMPLATES_DIR)/%=%)
 
 SOURCES = $(filter-out %.go,$(shell find $(TEMPLATES_DIR)/* -type f))
 OBJECTS = $(addsuffix .go, $(foreach src, $(SOURCES), $(call func_name_from_file,$(src))))
+DEPS = \
+	github.com/jteeuwen/go-bindata \
+	github.com/robertkrimen/terst \
+	github.com/jessevdk/go-flags \
+	bitbucket.org/pkg/inflect
+
 
 all:deps templates
 
@@ -31,10 +37,7 @@ install:
 	go install github.com/pksunkara/alpaca
 
 deps:
-	go get github.com/jteeuwen/go-bindata
-	go get github.com/robertkrimen/terst
-	go get github.com/jessevdk/go-flags
-	go get bitbucket.org/pkg/inflect
+	go get $(DEPS)
 
 clean:
 	rm -f ${TEMPLATES_DIR}/*.go

--- a/templates/php/lib/HttpClient/HttpClient.php
+++ b/templates/php/lib/HttpClient/HttpClient.php
@@ -109,6 +109,10 @@ class HttpClient
         unset($options['base']);
         unset($options['user_agent']);
 
+{{if .Api.no_verify_ssl}}
+        $options['verify'] = false;
+{{end}}
+
         $request = $this->createRequest($httpMethod, $path, null, $headers, $options);
 
         if ($httpMethod != 'GET') {

--- a/templates/python/lib/http_client/__init__.py
+++ b/templates/python/lib/http_client/__init__.py
@@ -76,6 +76,10 @@ class HttpClient():
 		kwargs['data'] = body
 		kwargs['allow_redirects'] = True
 
+{{if .Api.no_verify_ssl}}
+		kwargs['verify'] = False
+{{end}}
+
 		kwargs['params'] = kwargs['query'] if 'query' in kwargs else {}
 
 		if 'query' in kwargs:


### PR DESCRIPTION
Python: [fix] sub path url not working, eg: "base" : "http://mycoolapp.com/api"

  will spawned into "http://mycoolapp.com/[PATH]" we want to be "http://mycoolapp.com/api/[PATH]"

Python: [fix] Support for setting SSL verification by setting `verify_ssl` in `api.json`
