### PR TITLE
Python: fix docstrings pep257 warnings

### DIFF
--- a/templates/python/lib/api/api.py
+++ b/templates/python/lib/api/api.py
@@ -1,4 +1,5 @@
 class {{call .Fnc.camelize .Api.active.name}}(object):
+
     """{{index .Doc .Api.active.name "desc"}}{{with (index .Doc .Api.active.name "args")}}
 
     Args:{{end}}{{with $data := .}}{{range .Api.active.args}}

--- a/templates/python/lib/error/client_error.py
+++ b/templates/python/lib/error/client_error.py
@@ -1,5 +1,6 @@
 class ClientError(Exception):
-    """ClientException is used when the API returns an error"""
+
+    """ClientError is used when the API returns an error."""
 
     def __init__(self, message, code):
         super(ClientError, self).__init__()

--- a/templates/python/lib/http_client/__init__.py
+++ b/templates/python/lib/http_client/__init__.py
@@ -14,7 +14,8 @@ from .response_handler import ResponseHandler
 
 
 class HttpClient(object):
-    """Main HttpClient which is used by API classes"""
+
+    """Main HttpClient which is used by API classes."""
 
     def __init__(self, auth, options):
 {{if .Api.authorization.oauth}}
@@ -61,8 +62,9 @@ class HttpClient(object):
         return self.request(path, body, 'put', options)
 
     def request(self, path, body, method, options):
-        """Intermediate function which does three main things
+        """Request handle making requests and parsing responses.
 
+        Intermediate function which does three main things:
         - Transforms the body of request into correct format
         - Creates the requests with given parameters
         - Returns response body after parsing it into correct format
@@ -105,9 +107,9 @@ class HttpClient(object):
         )
 
     def create_request(self, method, path, options):
-        """Creating a request with the given arguments
+        """Creating a request with the given arguments.
 
-        If api_version is set, appends it immediately after host
+        If api_version is set, appends it immediately after host.
         """
         version = '/' + options['api_version'] if 'api_version' in options else ''
 {{if .Api.response.suffix}}
@@ -126,17 +128,17 @@ class HttpClient(object):
         return requests.request(method, path, **options)
 
     def get_body(self, response):
-        """Get response body in correct format"""
+        """Get response body in correct format."""
         return ResponseHandler.get_body(response)
 
     def set_body(self, request):
-        """Set request body in correct format"""
+        """Set request body in correct format."""
         return RequestHandler.set_body(request)
 
     def dict_key_lower(self, dic):
-        """Make dict keys all lower case"""
+        """Make dict keys all lower case."""
         return dict(zip(map(self.key_lower, dic.keys()), dic.values()))
 
     def key_lower(self, key):
-        """Make a function for lower case"""
+        """Make a function for lower case."""
         return key.lower()

--- a/templates/python/lib/http_client/auth_handler.py
+++ b/templates/python/lib/http_client/auth_handler.py
@@ -1,5 +1,6 @@
 class AuthHandler(object):
-    """AuthHandler takes care of devising the auth type and using it"""
+
+    """AuthHandler takes care of devising the auth type and using it."""
 {{if .Api.authorization.basic}}
     HTTP_PASSWORD = 0
 {{end}}{{if .Api.authorization.header}}
@@ -12,7 +13,7 @@ class AuthHandler(object):
         self.auth = auth
 
     def get_auth_type(self):
-        """Calculating the Authentication Type"""
+        """Calculating the Authentication Type."""
 {{if .Api.authorization.basic}}
         if 'username' in self.auth and 'password' in self.auth:
             return self.HTTP_PASSWORD
@@ -58,23 +59,23 @@ class AuthHandler(object):
         return request
 {{if .Api.authorization.basic}}
     def http_password(self, request):
-        """Basic Authorization with username and password"""
+        """Basic Authorization with username and password."""
         request['auth'] = (self.auth['username'], self.auth['password'])
         return request
 {{end}}{{if .Api.authorization.header}}
     def http_header(self, request):
-        """Authorization with HTTP header"""
+        """Authorization with HTTP header."""
         request['headers']['Authorization'] = '{{or .Api.authorization.header_prefix "token"}} ' + self.auth['http_header']
         return request
 {{end}}{{if .Api.authorization.oauth}}
     def url_secret(self, request):
-        """OAUTH2 Authorization with client secret"""
+        """OAUTH2 Authorization with client secret."""
         request['params']['client_id'] = self.auth['client_id']
         request['params']['client_secret'] = self.auth['client_secret']
         return request
 
     def url_token(self, request):
-        """OAUTH2 Authorization with access token"""
+        """OAUTH2 Authorization with access token."""
         request['params']['access_token'] = self.auth['access_token']
         return request
 {{end}}

--- a/templates/python/lib/http_client/error_handler.py
+++ b/templates/python/lib/http_client/error_handler.py
@@ -3,7 +3,8 @@ from .response_handler import ResponseHandler
 
 
 class ErrorHandler(object):
-    """ErrorHandler takes care of getting the error message from response body"""
+
+    """ErrorHandler takes care of getting the error message from response body."""
 
     @staticmethod
     def check_error(response, *args, **kwargs):

--- a/templates/python/lib/http_client/request_handler.py
+++ b/templates/python/lib/http_client/request_handler.py
@@ -3,21 +3,22 @@ import json
 
 
 class RequestHandler(object):
-    """RequestHandler takes care of encoding the request body into format given by options"""
+
+    """RequestHandler takes care of encoding the request body into format given by options."""
 
     @staticmethod
-    def renderKey(parents):
+    def render_key(parents):
         depth, new = 0, ''
 
         for x in parents:
-            old = "[%s]" if depth > 0 else "%s"
+            old = '[%s]' if depth > 0 else '%s'
             new += old % x
             depth += 1
 
         return new
 
     @staticmethod
-    def urlencode(data, parents=None, pairs=None):
+    def url_encode(data, parents=None, pairs=None):
         if pairs is None:
             pairs = {}
 

--- a/templates/python/lib/http_client/response.py
+++ b/templates/python/lib/http_client/response.py
@@ -1,5 +1,6 @@
 class Response(object):
-    """Response object contains the response returned by the client"""
+
+    """Response object contains the response returned by the client."""
 
     def __init__(self, body, code, headers):
         self.body = body

--- a/templates/python/lib/http_client/response_handler.py
+++ b/templates/python/lib/http_client/response_handler.py
@@ -1,5 +1,6 @@
 class ResponseHandler(object):
-    """ResponseHandler takes care of decoding the response body into suitable type"""
+
+    """ResponseHandler takes care of decoding the response body into suitable type."""
 
     @staticmethod
     def get_body(response):


### PR DESCRIPTION
Fixed warnings:
D400 First line should end with '.', not 't'
D203 Expected 1 blank line _before_ class docstring, found 0
Q000 Remove Double quotes
W293 blank line contains whitespace
N802 function name should be lowercase
Some more spelling mistakes
Some docs updates
