### PR TITLE
Fixes to Ruby template

### DIFF
--- a/alpaca/langs_ruby.go
+++ b/alpaca/langs_ruby.go
@@ -19,7 +19,7 @@ func WriteRuby(data *Data) {
 	RunTemplate("lib/client.rb", "client.rb", data)
 	RunTemplate("lib/http_client.rb", "http_client.rb", data)
 	RunTemplate("lib/error.rb", "error.rb", data)
-  RunTemplate("lib/version.rb", "version.rb", data)
+	RunTemplate("lib/version.rb", "version.rb", data)
 
 	MakeDir("error")
 	RunTemplate("lib/error/client_error.rb", "client_error.rb", data)

--- a/alpaca/langs_ruby.go
+++ b/alpaca/langs_ruby.go
@@ -19,6 +19,7 @@ func WriteRuby(data *Data) {
 	RunTemplate("lib/client.rb", "client.rb", data)
 	RunTemplate("lib/http_client.rb", "http_client.rb", data)
 	RunTemplate("lib/error.rb", "error.rb", data)
+  RunTemplate("lib/version.rb", "version.rb", data)
 
 	MakeDir("error")
 	RunTemplate("lib/error/client_error.rb", "client_error.rb", data)

--- a/templates/ruby/gemspec
+++ b/templates/ruby/gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
 
   gem.files = Dir["lib/**/*"]
 
-  gem.add_dependency "faraday", ">= 0.9.0"
-  gem.add_dependency "json", ">= 1.7.7"
+  gem.add_dependency "faraday", "~> 0.9", ">= 0.9.0"
+  gem.add_dependency "json", "~> 1.7", ">= 1.7.7"
 end

--- a/templates/ruby/lib/http_client/error_handler.rb
+++ b/templates/ruby/lib/http_client/error_handler.rb
@@ -27,7 +27,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
             end
 {{if .Api.Response.Formats.Json}}
             # If JSON, a particular field is taken and used
-            if type.include?("json") and body.is_a?(Hash)
+            if type && type.include?("json") && body.is_a?(Hash)
               if body.has_key?("{{.Api.Error.Message}}")
                 message = body["{{.Api.Error.Message}}"]
               else

--- a/templates/ruby/lib/http_client/error_handler.rb
+++ b/templates/ruby/lib/http_client/error_handler.rb
@@ -27,7 +27,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
             end
 {{if .Api.Response.Formats.Json}}
             # If JSON, a particular field is taken and used
-            if type && type.include?("json") && body.is_a?(Hash)
+            if type and type.include?("json") and body.is_a?(Hash)
               if body.has_key?("{{.Api.Error.Message}}")
                 message = body["{{.Api.Error.Message}}"]
               else

--- a/templates/ruby/lib/http_client/response_handler.rb
+++ b/templates/ruby/lib/http_client/response_handler.rb
@@ -10,7 +10,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
         body = response.body
 {{if .Api.Response.Formats.Json}}
         # Response body is in JSON
-        if type && type.include?("json")
+        if type and type.include?("json")
           body = JSON.parse body
         end
 {{end}}

--- a/templates/ruby/lib/http_client/response_handler.rb
+++ b/templates/ruby/lib/http_client/response_handler.rb
@@ -6,7 +6,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
     class ResponseHandler
 
       def self.get_body(response)
-        type = response.response["content-type"]
+        type = response.headers["content-type"]
         body = response.body
 {{if .Api.Response.Formats.Json}}
         # Response body is in JSON

--- a/templates/ruby/lib/http_client/response_handler.rb
+++ b/templates/ruby/lib/http_client/response_handler.rb
@@ -6,11 +6,11 @@ module {{call .Fnc.camelize .Pkg.Name}}
     class ResponseHandler
 
       def self.get_body(response)
-        type = response.headers["content-type"]
+        type = response.response_headers["content-type"]
         body = response.body
 {{if .Api.Response.Formats.Json}}
         # Response body is in JSON
-        if type.include?("json")
+        if type && type.include?("json")
           body = JSON.parse body
         end
 {{end}}

--- a/templates/ruby/lib/http_client/response_handler.rb
+++ b/templates/ruby/lib/http_client/response_handler.rb
@@ -6,7 +6,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
     class ResponseHandler
 
       def self.get_body(response)
-        type = response.response_headers["content-type"]
+        type = response.response["content-type"]
         body = response.body
 {{if .Api.Response.Formats.Json}}
         # Response body is in JSON

--- a/templates/ruby/lib/version.rb
+++ b/templates/ruby/lib/version.rb
@@ -1,0 +1,3 @@
+module {{call .Fnc.camelize .Pkg.Name}}
+  VERSION = "{{.Pkg.Version}}"
+end


### PR DESCRIPTION
One of the Faraday methods in the generated Ruby template was wrong, this PR fixes it. Also updates conditionals in case the API doesn't return a "content-type" header.