### PR TITLE
Update auth_handler.rb

### DIFF
--- a/templates/ruby/lib/http_client/auth_handler.rb
+++ b/templates/ruby/lib/http_client/auth_handler.rb
@@ -78,7 +78,7 @@ module {{call .Fnc.camelize .Pkg.Name}}
 {{if .Api.Authorization.Basic}}
       # Basic Authorization with username and password
       def http_password(env)
-        code = Base64.encode64 "#{@auth[:username]}:#{@auth[:password]}"
+        code = Base64.strict_encode64 "#{@auth[:username]}:#{@auth[:password]}"
 
         env[:request_headers]["Authorization"] = "Basic #{code}"
 


### PR DESCRIPTION
Avoid linefeed when using long username:password combination in Basic Authorization.